### PR TITLE
Fix api url

### DIFF
--- a/get-joke.sh
+++ b/get-joke.sh
@@ -3,6 +3,9 @@
 # Dad Jokes API endpoint
 jokes_json="https://fatherhood.gov/jsonapi/node/dad_jokes"
 
+# Where are all the cows?
+cows_directory="/opt/homebrew/Cellar/cowsay/3.04_1/share/cows/"
+
 if [[ ! $(which jq) ]]; then
   echo "The jokes are way funnier if you have the jq utility installed. https://stedolan.github.io/jq/" >&2
   exit 1
@@ -10,6 +13,11 @@ fi
 
 if [[ ! $(which cowsay) ]]; then
   echo "Saying jokes is better with cowsay. Promise! https://formulae.brew.sh/formula/cowsay" >&2
+  exit 1
+fi
+
+if [[ ! $(which shuf) ]]; then
+  echo "We need to shuffle our cows. https://formulae.brew.sh/formula/coreutils" >&2
   exit 1
 fi
 
@@ -27,7 +35,7 @@ joke_opener=$(echo "$jokes" | jq .data[$random_joke] | jq .attributes.field_joke
 joke_response=$(echo "$jokes" | jq .data[$random_joke] | jq .attributes.field_joke_response)
 
 # Get an animal to use with cowsay
-cow_to_say=$(find /usr/local/Cellar/cowsay/3.04/share/cows/ -name "*.cow" | shuf -n 1)
+cow_to_say=$(find $cows_directory -name "*.cow" | shuf -n 1)
 
 # Say the joke and punchline with cowsay.
 echo ""

--- a/get-joke.sh
+++ b/get-joke.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Dad Jokes API endpoint
-jokes_json="https://fatherhood.gov/jsonapi/node/dad_jokes"
+jokes_json="https://www.fatherhood.gov/jsonapi/node/dad_jokes"
 
 # Where are all the cows?
 cows_directory="/opt/homebrew/Cellar/cowsay/3.04_1/share/cows/"


### PR DESCRIPTION
Something with the fatherhood.gov website changed, and the url now appears to require `www` in to to work properly. This fixes the issue.